### PR TITLE
feature: Refactor color selections to support 8-bit colors...

### DIFF
--- a/git-activity
+++ b/git-activity
@@ -98,20 +98,20 @@ for day_n in $(seq 0 6); do
       value=$(( ${commits_per_day["${key}"]}00 / commits_max))
       if (( value <= 25 )); then
         # Low activity
-        printf "\x1b[38;2;14;100;41m%s%s" "$char_full" "$space"
+        printf "\x1b[38;5;22m%s%s" "$char_full" "$space"
       elif (( value <= 50 )); then
         # Mid-low activity
-        printf "\x1b[38;2;14;150;41m%s%s" "$char_full" "$space"
+        printf "\x1b[38;5;28m%s%s" "$char_full" "$space"
       elif (( value <= 75 )); then
         # Mid-high activity
-        printf "\x1b[38;2;14;200;41m%s%s" "$char_full" "$space"
+        printf "\x1b[38;5;34m%s%s" "$char_full" "$space"
       else
         # High activity
-        printf "\x1b[38;2;14;250;41m%s%s" "$char_full" "$space"
+        printf "\x1b[38;5;40m%s%s" "$char_full" "$space"
       fi
     elif [ $key -lt $last_day ]; then
       # No activity
-      printf "\u001b[38;5;250m%s%s" "$char_void" "$space"
+      printf "\x1b[38;5;250m%s%s" "$char_void" "$space"
     fi
   done
   printf "\n"
@@ -120,10 +120,10 @@ printf "\n"
 
 # Print legend
 printf "\e[m Less "
-printf "\u001b[38;5;250m%s " "$char_void"
-printf "\x1b[38;2;14;100;41m%s " "$char_full"
-printf "\x1b[38;2;14;150;41m%s " "$char_full"
-printf "\x1b[38;2;14;200;41m%s " "$char_full"
-printf "\x1b[38;2;14;250;41m%s " "$char_full"
+printf "\x1b[38;5;250m%s " "$char_void"
+printf "\x1b[38;5;22m%s " "$char_full"
+printf "\x1b[38;5;28m%s " "$char_full"
+printf "\x1b[38;5;34m%s " "$char_full"
+printf "\x1b[38;5;40m%s " "$char_full"
 printf "\e[mMore"
 printf "\n"


### PR DESCRIPTION
...since many terminals do not support 24-bit 'true color'. There's also no surefire way to detect color support, see https://github.com/termstandard/colors. Theoretically should fix #3

Screenshot of output from Terminal.app on MacOS for reference.

<img width="774" alt="Screen Shot 2022-06-01 at 7 18 39 AM" src="https://user-images.githubusercontent.com/3814007/171394365-dded55b7-5d85-4897-910d-4ad5014e8787.png">