### PR TITLE
improve compatibility and portability

### DIFF
--- a/git-activity
+++ b/git-activity
@@ -6,7 +6,7 @@ function usage() {
   cat <<EOF
 Usage: $0 [-h] [-n] [-s style]
 
-Display an activity graph (like the contribution graph on GitHub) for the 
+Display an activity graph (like the contribution graph on GitHub) for the
 current git repository and branch
 
 Available options:
@@ -62,22 +62,81 @@ esac
 # Use GNU date if available
 if date --version >/dev/null 2>&1 ; then
   function _date { date "$@" ;}
-elif gdate >/dev/null 2>&1 ; then
+elif command -v gdate >/dev/null 2>&1 ; then
   function _date { gdate "$@" ;}
 else
-  echo "You need to install coreutils to run this script (command 'gdate' is not available).";
-  exit 1;
+  # Try to use system date (BSD/macOS)
+  function _date {
+    # For BSD date on macOS
+    if [[ "$1" == "--date" ]] || [[ "$1" == "-d" ]]; then
+      shift
+      # Try to parse the date - this is a simplified version
+      if [[ "$1" =~ ^[0-9]+\ year ]]; then
+        # Handle relative dates like "1 year ago"
+        python3 -c "
+import datetime, sys, re
+from dateutil.relativedelta import relativedelta
+try:
+    from dateutil import parser
+    now = datetime.datetime.now()
+    text = sys.argv[1]
+    if 'year ago' in text:
+        years = int(text.split()[0])
+        dt = now - relativedelta(years=years)
+        print(dt.strftime('%Y-%m-%d'))
+except ImportError:
+    # Fallback if dateutil not installed
+    import subprocess
+    subprocess.run(['date', '-v', '-1y', '+%Y-%m-%d'])
+" "$1" 2>/dev/null || date -v-1y "+%Y-%m-%d"
+      else
+        # Try to parse absolute date
+        date -jf "%Y-%m-%d" "$1" "+%s" 2>/dev/null || date "$@"
+      fi
+    else
+      date "$@"
+    fi
+  }
 fi
 
 # Process commits per day
-declare -A commits_per_day
+# Using a more compatible approach instead of associative arrays
+declare -a commits_per_day
+for i in {0..371}; do
+  commits_per_day[i]=0
+done
+
 commits_max=0
-since=$(_date -d "$(_date -d '1 year ago + 1 day' +"%F -%u day")" +"%s")
-while read -r commits_n commits_date; do
+# Get since date - 1 year ago
+since_str=$(_date -d "1 year ago" "+%Y-%m-%d" 2>/dev/null || _date -v-1y "+%Y-%m-%d")
+since=$(_date -d "${since_str}" "+%s" 2>/dev/null || _date -jf "%Y-%m-%d" "${since_str}" "+%s")
+
+# Process git log output
+while IFS= read -r line; do
+  if [[ -z "$line" ]]; then continue; fi
+
+  # Parse uniq -c output (leading whitespace, count, date)
+  commits_n=$(echo "$line" | awk '{print $1}')
+  commits_date=$(echo "$line" | awk '{print $2}')
+
+  if [[ -z "$commits_date" ]]; then continue; fi
+
   (( commits_n > commits_max )) && commits_max=$commits_n
-  date_diff=$(( ($(_date --date="${commits_date} 13:00 UTC" "+%s") - since) / (60*60*24) ))
-  commits_per_day["${date_diff}"]=$commits_n
-done <<< $(git log --since="${since}" --date=short --pretty=format:'%ad'  | uniq -c)
+
+  # Calculate days difference
+  date_ts=$(_date -d "${commits_date} 13:00 UTC" "+%s" 2>/dev/null || _date -jf "%Y-%m-%d" "${commits_date}" "+%s")
+  date_diff=$(( (date_ts - since) / (60*60*24) ))
+
+  # Store if within range
+  if (( date_diff >= 0 && date_diff < 372 )); then
+    commits_per_day[date_diff]=$commits_n
+  fi
+done < <(git log --since="${since_str}" --date=short --pretty=format:'%ad' 2>/dev/null | sort | uniq -c)
+
+# If no commits found, set a default max to avoid division by zero
+if (( commits_max == 0 )); then
+  commits_max=1
+fi
 
 # Print name of months
 current_month=$(_date "+%b")
@@ -85,7 +144,7 @@ limit_columns=$(( 2 - ${#space} ))
 weeks_in_month=$(( limit_columns + 1 ))
 printf "\e[m    "
 for week_n in $(seq 0 52); do
-  month_week=$(_date -d "1 year ago + ${week_n} weeks" "+%b")
+  month_week=$(_date -d "1 year ago + ${week_n} weeks" "+%b" 2>/dev/null || _date -v-1y -v+"${week_n}w" "+%b")
   if [[ "${current_month}" != "${month_week}" ]]; then
     current_month=$month_week
     weeks_in_month=0
@@ -104,24 +163,29 @@ for day_n in $(seq 0 6); do
   printf '\e[m%-4s' "${name_of_days[day_n]}"
   for week_n in $(seq 0 52); do
     key=$(( week_n * 7 + day_n ))
-    if [[ -v commits_per_day["${key}"] ]]; then
-      value=$(( ${commits_per_day["${key}"]}00 / commits_max))
-      if (( value <= 25 )); then
+    value=${commits_per_day[key]:-0}
+
+    if (( value > 0 )); then
+      scaled_value=$(( value * 100 / commits_max ))
+      if (( scaled_value <= 25 )); then
         # Low activity
         printf "\x1b[38;5;22m%s%s" "$char_full" "$space"
-      elif (( value <= 50 )); then
+      elif (( scaled_value <= 50 )); then
         # Mid-low activity
         printf "\x1b[38;5;28m%s%s" "$char_full" "$space"
-      elif (( value <= 75 )); then
+      elif (( scaled_value <= 75 )); then
         # Mid-high activity
         printf "\x1b[38;5;34m%s%s" "$char_full" "$space"
       else
         # High activity
         printf "\x1b[38;5;40m%s%s" "$char_full" "$space"
       fi
-    elif [ $key -lt $last_day ]; then
+    elif (( key < last_day )); then
       # No activity
       printf "\x1b[38;5;250m%s%s" "$char_void" "$space"
+    else
+      # Future or no data
+      printf "  "
     fi
   done
   printf "\n"


### PR DESCRIPTION
This PR fixes some compatibility issues that prevented the script from working on systems with:

1. Older Bash versions (3.2+, common on macOS)
2. BSD date instead of GNU date (macOS default)
3. Fish shell environments

The errors I was getting on macOS with Fish shell:

```
/ForkedRepo/git-activity/git-activity: line 73: declare: -A: invalid option
declare: usage: declare [-afFirtx] [-p] [name[=value] ...]
gdate: invalid date ‘2025-12-13 3 2025-12-12 3 2025-12-11 6 2025-12-10 1 2025-12-09 7 2025-12-05 3 2025-12-04 4 2025-12-03 2 2025-11-27 3 2025-11-26 3 2025-11-25 2 2025-11-24 1 2025-11-23 1 2025-11-22 1 2025-11-18 2 2025-11-15 4 2025-11-13 8 2025-11-12 7 2025-11-11 4 2025-11-10 11 2025-11-08 8 2025-11-07 1 2025-10-31 2 2025-10-30 3 2025-10-25 6 2025-10-23 1 2025-10-22 3 2025-10-18 3 2025-10-15 6 2025-10-07 1 2025-10-01 3 2025-09-30 3 2025-09-29 3 2025-09-27 3 2025-09-26 8 2025-09-24 1 2025-09-22 2 2025-09-21 5 2025-09-20 2 2025-09-19 7 2025-09-18 2 2025-09-16 5 2025-09-15 3 2025-09-13 2 2025-09-08 1 2025-09-06 2 2025-09-05 4 2025-09-02 2 2025-08-29 4 2025-08-28 6 2025-08-27 2 2025-08-25 7 2025-08-24 12 2025-08-23 2 2025-08-21 8 2025-08-20 8 2025-08-19 3 2025-08-17 3 2025-08-15 1 2025-08-14 5 2025-08-13 5 2025-08-10 2 2025-08-09 6 2025-08-08 7 2025-08-07 1 2025-08-06 3 2025-08-05 1 2025-08-04 1 2025-08-03 2 2025-07-31 1 2025-07-25 2 2025-07-24 3 2025-07-23 1 2025-07-16 4 2025-06-25 6 2025-06-24 1 2025-03-27 2 2025-02-27 2 2025-02-26 3 2025-02-25 3 2025-02-24 4 2025-02-23 13:00 UTC’
/ForkedRepo/git-activity/git-activity: line 79: commits_per_day["${date_diff}"]: bad array subscript
       Jan Feb Mar  Apr May Jun  Jul Aug  Sep Oct Nov  Dec
/ForkedRepo/git-activity/git-activity: line 106: conditional binary operator expected
/ForkedRepo/git-activity/git-activity: line 106: syntax error near `commits_per_day["${key}"]'
/ForkedRepo/git-activity/git-activity: line 106: `    if [[ -v commits_per_day["${key}"] ]]; then'

```

The following changes are made:

1. Replaced associative arrays with indexed arrays
2. Improved date command compatibility
3. Fixed array element existence checking

Testing

The script now works on 
1. macOS with default Bash 3.2 and BSD date
2. Linux with GNU date and Bash 4+